### PR TITLE
Add org.mpris.MediaPlayer2.amarok to dbus owns

### DIFF
--- a/org.kde.amarok.json
+++ b/org.kde.amarok.json
@@ -30,7 +30,8 @@
         "--talk-name=org.kde.amarok.Mpris2Extensions.Player",
         "--talk-name=org.kde.kglobalaccel",
         "--talk-name=org.kde.kcookiejar5",
-        "--talk-name=org.kde.StatusNotifierWatcher"
+        "--talk-name=org.kde.StatusNotifierWatcher",
+        "--own-name=org.mpris.MediaPlayer2.amarok"
     ],
     "cleanup-commands": [
         "/app/cleanup-BaseApp.sh"


### PR DESCRIPTION
MPRIS is broken in the current build, which breaks desktop integration and global playback controls. Adding the amarok MPRIS dbus name to the owns array fixes this.

I haven't built this so please test! I'm just mimmicking the syntax I saw in another flatpak mpris issue. I have confirmed that this works when added with flatseal.