### PR TITLE
Add appstream metadata improvement patch

### DIFF
--- a/aad46c07ae6b1acbda4fdd416d250d5144ea2c55.patch
+++ b/aad46c07ae6b1acbda4fdd416d250d5144ea2c55.patch
@@ -1,0 +1,40 @@
+From aad46c07ae6b1acbda4fdd416d250d5144ea2c55 Mon Sep 17 00:00:00 2001
+From: Tuomas Nurmi <tuomas@norsumanageri.org>
+Date: Wed, 8 May 2024 22:40:31 +0300
+Subject: [PATCH] Add appdata connection to previous app id
+
+Based on discussion at https://invent.kde.org/multimedia/amarok/-/issues/9
+---
+ src/org.kde.amarok.appdata.xml | 10 +++++++---
+ 1 file changed, 7 insertions(+), 3 deletions(-)
+
+diff --git a/src/org.kde.amarok.appdata.xml b/src/org.kde.amarok.appdata.xml
+index 2eccb46e9c..0f976168bc 100644
+--- a/src/org.kde.amarok.appdata.xml
++++ b/src/org.kde.amarok.appdata.xml
+@@ -1,6 +1,13 @@
+ <?xml version="1.0" encoding="utf-8"?>
+ <component type="desktop">
+   <id>org.kde.amarok</id>
++  <provides>
++    <id>org.kde.amarok.desktop</id>
++    <binary>amarok</binary>
++  </provides>
++  <replaces>
++    <id>org.kde.amarok.desktop</id>
++  </replaces>
+   <launchable type="desktop-id">org.kde.amarok.desktop</launchable>
+   <metadata_license>CC0-1.0</metadata_license>
+   <project_license>GPL-2.0+</project_license>
+@@ -510,9 +517,6 @@
+   </screenshots>
+   <content_rating type="oars-1.1"/>
+   <project_group>KDE</project_group>
+-  <provides>
+-    <binary>amarok</binary>
+-  </provides>
+   <releases>
+     <release version="3.0.0" date="2024-04-29" type="stable"/>
+     <release version="2.9.82" date="2024-04-12" type="development"/>
+-- 
+2.44.0

--- a/org.kde.amarok.json
+++ b/org.kde.amarok.json
@@ -192,6 +192,10 @@
                 {
                     "type": "patch",
                     "path": "1df673defcc4ea62edbf1a964eec289a42499a42.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "aad46c07ae6b1acbda4fdd416d250d5144ea2c55.patch"
                 }
             ]
         }


### PR DESCRIPTION
Adding the changes from upstream that should fix the split by filling in the provides and replaces tags.

(Didn't actually test the commit in this PR in any way yet.)