### PR TITLE
Replace host filesystem access to xdg-music

### DIFF
--- a/org.kde.amarok.json
+++ b/org.kde.amarok.json
@@ -23,7 +23,7 @@
         "--socket=fallback-x11",
         "--socket=pulseaudio",
         "--device=dri",
-        "--filesystem=home",
+        "--filesystem=xdg-music",
         "--filesystem=/run/media",
         "--filesystem=/media",
         "--system-talk-name=org.freedesktop.UDisks2",


### PR DESCRIPTION
Replaced filesystem access from home to `xdg-music` as specified in the Flatpak permissions guide - https://docs.flatpak.org/en/latest/sandbox-permissions.html

It's better to use the xdg spec in place of the path. Also addresses Issue #6 and makes the sandbox a little more robust.